### PR TITLE
Add function to revert all dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,3 +100,22 @@ from the lookup table.
 ```elixir
 Resolve.revert(Module)
 ```
+
+### Unit testing
+
+It can be more convenient to revert all of the dependencies after each unit test
+runs, rather than keeping track of and reverting individual dependencies. This
+can be done with the `revert_all` function if it is placed in a test helper or
+configuration file, depending on how your test suite works.
+
+ESpec example:
+
+```ex
+# spec_helper.exs
+
+ESpec.configure(fn config ->
+  config.finally(fn _shared ->
+    Resolve.revert_all
+  end)
+end)
+```

--- a/lib/resolve.ex
+++ b/lib/resolve.ex
@@ -73,6 +73,21 @@ defmodule Resolve do
     :ok
   end
 
+  @doc """
+  Revert all dependencies to their original modules.
+
+  This can be used when unit testing to ensure dependencies are cleared out
+  between tests.
+  """
+  @spec revert_all() :: any
+  def revert_all do
+    ensure_ets_is_running()
+
+    :ets.delete_all_objects(:resolve)
+
+    :ok
+  end
+
   defp ensure_ets_is_running do
     case :ets.whereis(:resolve) do
       :undefined -> :ets.new(:resolve, [:public, :named_table, read_concurrency: true])


### PR DESCRIPTION
This PR adds `Resolve.revert_all` to revert all of the mapped dependencies back to their original modules. The intention is for it to be called between unit tests to conveniently reset all of the dependency mappings.