### PR TITLE
Change resolve_all to a hidden function

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,22 +100,3 @@ from the lookup table.
 ```elixir
 Resolve.revert(Module)
 ```
-
-### Unit testing
-
-It can be more convenient to revert all of the dependencies after each unit test
-runs, rather than keeping track of and reverting individual dependencies. This
-can be done with the `revert_all` function if it is placed in a test helper or
-configuration file, depending on how your test suite works.
-
-ESpec example:
-
-```ex
-# spec_helper.exs
-
-ESpec.configure(fn config ->
-  config.finally(fn _shared ->
-    Resolve.revert_all
-  end)
-end)
-```

--- a/lib/resolve.ex
+++ b/lib/resolve.ex
@@ -73,12 +73,12 @@ defmodule Resolve do
     :ok
   end
 
-  @doc """
-  Revert all dependencies to their original modules.
-
-  This can be used when unit testing to ensure dependencies are cleared out
-  between tests.
-  """
+  @doc false
+  # Revert all dependencies to their original modules.
+  #
+  # This function may be helpful in some cases for unit testing or
+  # troubleshooting. However, something unrelated to Resolve is likely
+  # wrong if you're reaching for this.
   @spec revert_all() :: any
   def revert_all do
     ensure_ets_is_running()


### PR DESCRIPTION
After further troubleshooting of an issue, Resolve turned out not to be the problem after all. The `revert_all` function may still be helpful for anyone else who needs to troubleshoot dependencies in the future so I've left the code in, but it's being removed from the public docs to discourage it from becoming common place.